### PR TITLE
PoC of gradient

### DIFF
--- a/qiskit/evaluators/expectation_value.ipynb
+++ b/qiskit/evaluators/expectation_value.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "1e757f1b",
+   "id": "e2c3d0f4",
    "metadata": {
     "tags": []
    },
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31bc9934",
+   "id": "5485c7d2",
    "metadata": {},
    "source": [
     "# ExpectationValue"
@@ -24,7 +24,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "a024d5e8-4460-473c-82d7-a83c8b0dc3eb",
+   "id": "53454a61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -34,7 +34,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "fee95b3f",
+   "id": "2af11a78",
    "metadata": {},
    "outputs": [
     {
@@ -68,7 +68,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "60af9f40",
+   "id": "acee2aa2",
    "metadata": {},
    "outputs": [
     {
@@ -82,7 +82,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/aa406165/Git/qiskit-core/qiskit/quantum_info/states/statevector.py:444: DeprecationWarning: The SparsePauliOp.table method is deprecated as of Qiskit Terra 0.19.0 and will be removed no sooner than 3 months after the releasedate. Use SparsePauliOp.paulis method instead.\n",
+      "/Users/ima/tasks/1_2021/qiskit/terra/qiskit/quantum_info/states/statevector.py:444: DeprecationWarning: The SparsePauliOp.table method is deprecated as of Qiskit Terra 0.19.0 and will be removed no sooner than 3 months after the releasedate. Use SparsePauliOp.paulis method instead.\n",
       "  for z, x, coeff in zip(oper.table.Z, oper.table.X, oper.coeffs)\n"
      ]
     }
@@ -98,7 +98,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16dd493e",
+   "id": "79e6d92d",
    "metadata": {},
    "source": [
     "## ExpectationValue class"
@@ -107,7 +107,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "8d3036e8",
+   "id": "0938d0ab",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -116,7 +116,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ee720e69",
+   "id": "2d0026e1",
    "metadata": {},
    "source": [
     "### PauliExpectationValue\n",
@@ -127,7 +127,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "e60ada70",
+   "id": "58ffdb65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -139,7 +139,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "3989c189",
+   "id": "c728a8c3",
    "metadata": {
     "tags": []
    },
@@ -148,15 +148,13 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "no max_experiments for this backend: aer_simulator\n",
-      "/Users/aa406165/Git/qiskit-core/qiskit/evaluators/expectation_value/pauli_expectation_value.py:85: DeprecationWarning: Back-references to from Bit instances to their containing Registers have been deprecated. Instead, inspect Registers to find their contained Bits.\n",
-      "  layout = [qr[0].index for _, qr, _ in transpiled_state[-state.num_qubits :]]\n"
+      "no max_experiments for backend 'aer_simulator'. Set 1000000 as max_experiments.\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "ExpectationValueResult(value=1.783203125, variance=11.119335174560547, confidence_interval=(1.6247985366532072, 1.9416077133467928))"
+       "ExpectationValueResult(value=1.84765625, variance=11.072105407714844, confidence_interval=(1.6896409070896277, 2.0056715929103723))"
       ]
      },
      "execution_count": 7,
@@ -172,20 +170,20 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "5e244ee2",
+   "id": "6432525d",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "no max_experiments for this backend: aer_simulator\n"
+      "no max_experiments for backend 'aer_simulator'. Set 1000000 as max_experiments.\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "ExpectationValueResult(value=1.76953125, variance=11.197494506835938, confidence_interval=(1.6097795448066898, 1.9292829551933102))"
+       "ExpectationValueResult(value=1.9453125, variance=10.988372802734375, confidence_interval=(1.7880903253842175, 2.1025346746157823))"
       ]
      },
      "execution_count": 8,
@@ -204,21 +202,21 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "39627b38-e650-4ba8-b295-a68563a33905",
+   "id": "3155ae4b",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "no max_experiments for this backend: aer_simulator\n"
+      "no max_experiments for backend 'aer_simulator'. Set 1000000 as max_experiments.\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "ExpectationValueArrayResult(values=array([1.828     , 0.12533333]), variances=array([11.143024  , 10.34466756]), confidence_intervals=array([[1.73510685, 1.92089315],\n",
-       "       [0.03225701, 0.21840966]]))"
+       "ExpectationValueArrayResult(values=array([1.87333333, 0.13066667]), variances=array([11.07357689, 10.33122844]), confidence_intervals=array([[1.78082897, 1.9658377 ],\n",
+       "       [0.03751989, 0.22381344]]))"
       ]
      },
      "execution_count": 9,
@@ -236,21 +234,21 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "7f92d32c-5eef-4468-a2b8-acc9fb90d360",
+   "id": "a359f015",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "no max_experiments for this backend: aer_simulator\n"
+      "no max_experiments for backend 'aer_simulator'. Set 1000000 as max_experiments.\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "ExpectationValueArrayResult(values=array([1.88232422, 0.16967773]), variances=array([11.11922276, 10.50249666]), confidence_intervals=array([[1.82605823, 1.93859021],\n",
-       "       [0.11286499, 0.22649048]]))"
+       "ExpectationValueArrayResult(values=array([1.8527832 , 0.15209961]), variances=array([11.13814348, 10.56786078]), confidence_intervals=array([[1.79654633, 1.90902008],\n",
+       "       [0.09517763, 0.20902159]]))"
       ]
      },
      "execution_count": 10,
@@ -266,7 +264,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "78b2e0bf",
+   "id": "ef5c06e5",
    "metadata": {},
    "source": [
     "### Exact simulation by SaveExpectationValueVariance"
@@ -275,7 +273,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "1f5dca21",
+   "id": "0f674e90",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -285,7 +283,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "3ed3d334",
+   "id": "076d0bae",
    "metadata": {},
    "outputs": [
     {
@@ -307,7 +305,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "c7e99470",
+   "id": "3aaa505c",
    "metadata": {},
    "outputs": [
     {
@@ -328,7 +326,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7ed181f7-7463-4432-b5f6-c40ddfe4330e",
+   "id": "f17f9cc4",
    "metadata": {},
    "source": [
     "### Transpiled Circuits"
@@ -336,8 +334,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
-   "id": "5cb7102e-117f-42b9-b41f-c22f1f6ef179",
+   "execution_count": 14,
+   "id": "a4128963",
    "metadata": {},
    "outputs": [
     {
@@ -356,7 +354,7 @@
       "               └────┘└──────────────┘└────┘└────────┘     └────┘»\n",
       "ancilla_2 -> 4 ─────────────────────────────────────────────────»\n",
       "                                                                »\n",
-      "        c11: 2/═════════════════════════════════════════════════»\n",
+      "         c4: 2/═════════════════════════════════════════════════»\n",
       "                                                                »\n",
       "«                                                                          »\n",
       "«ancilla_0 -> 0 ───────────────────────────────────────────────────────────»\n",
@@ -369,7 +367,7 @@
       "«               └──────────────┘└────┘└────────┘     └────┘└──────────────┘»\n",
       "«ancilla_2 -> 4 ───────────────────────────────────────────────────────────»\n",
       "«                                                                          »\n",
-      "«        c11: 2/═══════════════════════════════════════════════════════════»\n",
+      "«         c4: 2/═══════════════════════════════════════════════════════════»\n",
       "«                                                                          »\n",
       "«                                                                 \n",
       "«ancilla_0 -> 0 ──────────────────────────────────────────────────\n",
@@ -382,7 +380,7 @@
       "«               └────┘└────────┘└─────────┘└────┘└─────────┘└╥┘ ║ \n",
       "«ancilla_2 -> 4 ─────────────────────────────────────────────╫──╫─\n",
       "«                                                            ║  ║ \n",
-      "«        c11: 2/═════════════════════════════════════════════╩══╩═\n",
+      "«         c4: 2/═════════════════════════════════════════════╩══╩═\n",
       "«                                                            0  1 \n",
       "{'basis': 'XX', 'coeff': 1.0}\n",
       "\n",
@@ -398,7 +396,7 @@
       "               └────┘└──────────────┘└────┘└────────┘     └────┘»\n",
       "ancilla_2 -> 4 ─────────────────────────────────────────────────»\n",
       "                                                                »\n",
-      "        c11: 2/═════════════════════════════════════════════════»\n",
+      "         c4: 2/═════════════════════════════════════════════════»\n",
       "                                                                »\n",
       "«                                                                          »\n",
       "«ancilla_0 -> 0 ───────────────────────────────────────────────────────────»\n",
@@ -411,7 +409,7 @@
       "«               └──────────────┘└────┘└────────┘     └────┘└──────────────┘»\n",
       "«ancilla_2 -> 4 ───────────────────────────────────────────────────────────»\n",
       "«                                                                          »\n",
-      "«        c11: 2/═══════════════════════════════════════════════════════════»\n",
+      "«         c4: 2/═══════════════════════════════════════════════════════════»\n",
       "«                                                                          »\n",
       "«                                                      \n",
       "«ancilla_0 -> 0 ───────────────────────────────────────\n",
@@ -424,7 +422,7 @@
       "«               └────┘└────────┘└────┘└─────────┘└╥┘ ║ \n",
       "«ancilla_2 -> 4 ──────────────────────────────────╫──╫─\n",
       "«                                                 ║  ║ \n",
-      "«        c11: 2/══════════════════════════════════╩══╩═\n",
+      "«         c4: 2/══════════════════════════════════╩══╩═\n",
       "«                                                 0  1 \n",
       "{'basis': 'YY', 'coeff': 2.0}\n",
       "\n",
@@ -440,7 +438,7 @@
       "               └────┘└──────────────┘└────┘└────────┘     └────┘»\n",
       "ancilla_2 -> 4 ─────────────────────────────────────────────────»\n",
       "                                                                »\n",
-      "        c11: 2/═════════════════════════════════════════════════»\n",
+      "         c4: 2/═════════════════════════════════════════════════»\n",
       "                                                                »\n",
       "«                                                                          »\n",
       "«ancilla_0 -> 0 ───────────────────────────────────────────────────────────»\n",
@@ -453,7 +451,7 @@
       "«               └──────────────┘└────┘└────────┘     └────┘└──────────────┘»\n",
       "«ancilla_2 -> 4 ───────────────────────────────────────────────────────────»\n",
       "«                                                                          »\n",
-      "«        c11: 2/═══════════════════════════════════════════════════════════»\n",
+      "«         c4: 2/═══════════════════════════════════════════════════════════»\n",
       "«                                                                          »\n",
       "«                                     \n",
       "«ancilla_0 -> 0 ──────────────────────\n",
@@ -466,11 +464,11 @@
       "«               └────┘└────────┘└╥┘ ║ \n",
       "«ancilla_2 -> 4 ─────────────────╫──╫─\n",
       "«                                ║  ║ \n",
-      "«        c11: 2/═════════════════╩══╩═\n",
+      "«         c4: 2/═════════════════╩══╩═\n",
       "«                                0  1 \n",
       "{'basis': 'ZZ', 'coeff': 3.0}\n",
       "\n",
-      "ExpectationValueResult(value=1.156005859375, variance=12.818515956401825, confidence_interval=(1.0932408623134988, 1.2187708564365012))\n"
+      "ExpectationValueResult(value=1.341796875, variance=12.611431121826172, confidence_interval=(1.1661147100568412, 1.5174790399431588))\n"
      ]
     }
    ],
@@ -490,7 +488,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a262bc31",
+   "id": "ad8e29f8",
    "metadata": {},
    "source": [
     "### Transpile options and Run options"
@@ -499,13 +497,13 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "40ffcc90",
+   "id": "8184fa63",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "ExpectationValueResult(value=1.2063796790962618, variance=12.756041185106277, confidence_interval=(1.2007169677238276, 1.2120423904686959))"
+       "ExpectationValueResult(value=1.1833734963853253, variance=12.776249008490854, confidence_interval=(1.165449013944694, 1.2012979788259566))"
       ]
      },
      "execution_count": 15,
@@ -517,20 +515,20 @@
     "expval = PauliExpectationValue(ansatz, observable, backend=backend)\n",
     "# setter\n",
     "expval.set_transpile_options(optimization_level=2)\n",
-    "expval.set_run_options(shots=1_000_000)\n",
+    "expval.set_run_options(shots=100_000)\n",
     "expval.evaluate([0, 1, 1, 2, 3, 5])"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "3d56d394",
+   "id": "7919b965",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "ExpectationValueResult(value=1.285888671875, variance=12.683094680309296, confidence_interval=(1.2235326041673829, 1.3482447395826171))"
+       "ExpectationValueResult(value=1.168212890625, variance=12.758465230464935, confidence_interval=(1.1056568133433762, 1.2307689679066238))"
       ]
      },
      "execution_count": 16,
@@ -546,13 +544,13 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "075c0124",
+   "id": "bee4e607",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "ExpectationValueResult(value=1.0066666666666668, variance=12.707511111111113, confidence_interval=(0.6807484258332879, 1.3325849075000458))"
+       "ExpectationValueResult(value=1.1866666666666665, variance=12.703377777777778, confidence_interval=(0.8607444915023681, 1.512588841830965))"
       ]
      },
      "execution_count": 17,
@@ -567,7 +565,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "59e716ee-e63d-4437-8287-3709d18c2e29",
+   "id": "aa8c146e",
    "metadata": {},
    "source": [
     "### Composite Evaluator"
@@ -576,7 +574,7 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "d73181d0-fe07-44d5-9045-0736f6a3f1d5",
+   "id": "bd19f3bd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -586,7 +584,7 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "2e4ed8f5-6992-4abe-92d7-84ec94494fff",
+   "id": "9bdf69c5",
    "metadata": {},
    "outputs": [
     {
@@ -607,7 +605,7 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "48ad721a-2a0f-4a60-8e8c-bb19eb60d9a1",
+   "id": "47503aa9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -617,7 +615,7 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "a45de43c-0062-4310-b31c-50e23fcfb263",
+   "id": "87fd8067",
    "metadata": {},
    "outputs": [
     {
@@ -638,13 +636,13 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "d1822194-5230-4725-8695-d1f182643313",
+   "id": "45fcd694",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "CompositeResult(items=[ExpectationValueResult(value=1.225830078125, variance=12.6898073554039, confidence_interval=(1.1634853090964266, 1.2881748471535734)), ExpectationValueResult(value=1.225830078125, variance=12.6898073554039, confidence_interval=(1.1634853090964266, 1.2881748471535734)), ExpectationValueResult(value=1.225830078125, variance=12.6898073554039, confidence_interval=(1.1634853090964266, 1.2881748471535734))])"
+       "CompositeResult(items=[ExpectationValueResult(value=1.19091796875, variance=12.800391912460327, confidence_interval=(1.1282004069837166, 1.2536355305162834)), ExpectationValueResult(value=1.19091796875, variance=12.800391912460327, confidence_interval=(1.1282004069837166, 1.2536355305162834)), ExpectationValueResult(value=1.19091796875, variance=12.800391912460327, confidence_interval=(1.1282004069837166, 1.2536355305162834))])"
       ]
      },
      "execution_count": 22,
@@ -658,32 +656,24 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0efdd073",
+   "id": "c9820922",
    "metadata": {},
    "source": [
-    "### Mitigator"
+    "### Readout error mitigation"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "49b6629b",
+   "id": "d5ff674c",
    "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/aa406165/Git/qiskit-core/qiskit/evaluators/expectation_value/pauli_expectation_value.py:85: DeprecationWarning: Back-references to from Bit instances to their containing Registers have been deprecated. Instead, inspect Registers to find their contained Bits.\n",
-      "  layout = [qr[0].index for _, qr, _ in transpiled_state[-state.num_qubits :]]\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "w/o mitigation shots=2000, result=ExpectationValueResult(value=1.2040000000000002, variance=12.79971, confidence_interval=(1.0770517475204142, 1.3309482524795861))\n",
-      "w/  mitigation shots=2000, result=ExpectationValueResult(value=1.3676132384195576, variance=12.250525734116593, confidence_interval=(1.2445587091474666, 1.4906677676916487))\n"
+      "w/o mitigation shots=2000, result=ExpectationValueResult(value=1.251, variance=12.780410999999999, confidence_interval=(1.1241444207813454, 1.3778555792186544))\n",
+      "w/  mitigation shots=2000, result=ExpectationValueResult(value=1.3008475460143756, variance=12.538071538402928, confidence_interval=(1.1756829842352605, 1.4260121077934906))\n"
      ]
     }
    ],
@@ -692,7 +682,7 @@
     "\n",
     "backend = AerSimulator.from_backend(FakeBogota())\n",
     "mit = ReadoutErrorMitigation(\n",
-    "    backend, mitigation=\"tensored\", refresh=1, shots=2000, mit_pattern=[[0], [1]]\n",
+    "    backend, mitigation=\"tensored\", refresh=600, shots=2000, mit_pattern=[[0], [1]]\n",
     ")\n",
     "expval_raw = PauliExpectationValue(ansatz, observable, backend=backend)\n",
     "expval_mit = PauliExpectationValue(ansatz, observable, backend=mit)\n",
@@ -706,9 +696,123 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "7850dc7c",
+   "metadata": {},
+   "source": [
+    "### Gradient of expectation value"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "19d0c608",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from qiskit.evaluators.expectation_value.expectation_value_gradient import FiniteDiffGradient, ParameterShiftGradient"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "54303792",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fin diff w/o mit [-1.4  -1.75 -0.25 -0.87 -0.54 -0.93]\n",
+      "param shift w/o mit [0.099  1.403  0.7745 1.3005 0.941  1.4915]\n",
+      "fin diff w/  mit [-1.29058112  0.21874482 -0.70796302 -0.8627791  -1.15390334  1.86511967]\n",
+      "param shift w/  mit [0.16088677 1.56708761 0.78777228 1.40973804 1.21876092 1.75961842]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# exact_expval = ExactExpectationValue(ansatz, observable, backend=AerSimulator())\n",
+    "# exact_findiff = FiniteDiffGradient(exact_expval, 1e-8)\n",
+    "# print(f\"fin diff of exact {exact_findiff.evaluate([0, 1, 1, 2, 3, 5]).values}\")\n",
+    "\n",
+    "shots = 2000\n",
+    "findiff = FiniteDiffGradient(expval_raw, 1e-1)\n",
+    "paramshift = ParameterShiftGradient(expval_raw)\n",
+    "print(f\"fin diff w/o mit {findiff.evaluate([0, 1, 1, 2, 3, 5], shots=shots).values}\")\n",
+    "print(f\"param shift w/o mit {paramshift.evaluate([0, 1, 1, 2, 3, 5], shots=shots).values}\")\n",
+    "\n",
+    "findiff = FiniteDiffGradient(expval_mit, 1e-1)\n",
+    "paramshift = ParameterShiftGradient(expval_mit)\n",
+    "print(f\"fin diff w/  mit {findiff.evaluate([0, 1, 1, 2, 3, 5], shots=shots).values}\")\n",
+    "print(f\"param shift w/  mit {paramshift.evaluate([0, 1, 1, 2, 3, 5], shots=shots).values}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "abb00119",
+   "metadata": {},
+   "source": [
+    "### Scipy optimizer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "c1358216",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "no max_experiments for backend 'aer_simulator'. Set 1000000 as max_experiments.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      fun: -4.609263861759417\n",
+      " hess_inv: array([[ 0.20515557, -0.23576343, -0.0484571 ,  0.20094939,  0.03524248,\n",
+      "        -0.14764537],\n",
+      "       [-0.23576343,  0.75165856,  0.43825389, -0.75034371, -0.77853314,\n",
+      "         0.13959995],\n",
+      "       [-0.0484571 ,  0.43825389,  0.48110665, -0.61393319, -0.7352592 ,\n",
+      "         0.06838818],\n",
+      "       [ 0.20094939, -0.75034371, -0.61393319,  1.18642541,  1.14208052,\n",
+      "        -0.19590744],\n",
+      "       [ 0.03524248, -0.77853314, -0.7352592 ,  1.14208052,  1.60009024,\n",
+      "         0.01585804],\n",
+      "       [-0.14764537,  0.13959995,  0.06838818, -0.19590744,  0.01585804,\n",
+      "         0.30897136]])\n",
+      "      jac: array([ 0.004 ,  0.3395, -0.1235,  0.31  ,  0.34  , -0.295 ])\n",
+      "  message: 'Desired error not necessarily achieved due to precision loss.'\n",
+      "     nfev: 50\n",
+      "      nit: 9\n",
+      "     njev: 32\n",
+      "   status: 2\n",
+      "  success: False\n",
+      "        x: array([-1.62739621,  1.81345777,  3.21381643, -1.46110082, -2.33609977,\n",
+      "        0.96455941])\n"
+     ]
+    }
+   ],
+   "source": [
+    "from scipy.optimize import minimize\n",
+    "shot = 10000\n",
+    "backend = AerSimulator()\n",
+    "expval = PauliExpectationValue(ansatz, observable, backend=backend)\n",
+    "paramshift = ParameterShiftGradient(expval)\n",
+    "# this may take a long time...\n",
+    "result = minimize(lambda x: expval_mit.evaluate(x, shots=shots).value, np.zeros(6),\n",
+    "                  jac=lambda x: paramshift.evaluate(x, shots=shots).values)\n",
+    "print(result)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fd4ce213",
+   "id": "a7a45b3e",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -716,12 +820,12 @@
  ],
  "metadata": {
   "interpreter": {
-   "hash": "55198b233f406dc59b712acd847cdd7a571fa057c585d106ba05aad0d31ffb93"
+   "hash": "5e4e4c11f881147a334259b58ba9612deb3e7d7392f1658006398e861f6e4956"
   },
   "kernelspec": {
-   "display_name": "Terra",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "terra"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -733,7 +837,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.4"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/qiskit/evaluators/expectation_value/exact_expectation_value.py
+++ b/qiskit/evaluators/expectation_value/exact_expectation_value.py
@@ -119,7 +119,7 @@ class ExactPostprocessing(BasePostprocessing):
 
     def execute(self, result: Union[dict, ShotResult]) -> ExpectationValueResult:
 
-        #TOOD: validate
+        # TODO: validate
 
         expval, variance = result["expectation_value_variance"]
 

--- a/qiskit/evaluators/expectation_value/expectation_value_gradient.py
+++ b/qiskit/evaluators/expectation_value/expectation_value_gradient.py
@@ -1,0 +1,160 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""
+Expectation value gradient class
+"""
+
+from __future__ import annotations
+
+from typing import Union, cast
+
+import numpy as np
+
+from ..results.expectation_value_gradient_result import ExpectationValueGradientResult
+from .expectation_value import ExpectationValue
+
+
+class BaseExpectationValueGradient:
+    """
+    Expectation Value Gradient class
+    """
+
+    def __init__(self, expval: ExpectationValue):
+        self._expval = expval
+
+    def evaluate(
+        self, parameters: Union[list[float], np.ndarray], **run_options
+    ) -> ExpectationValueGradientResult:
+        return NotImplemented
+
+
+class FiniteDiffGradient(BaseExpectationValueGradient):
+    """
+    Finite difference of expectation values
+    """
+
+    def __init__(self, expval: ExpectationValue, epsilon: float):
+        super(FiniteDiffGradient, self).__init__(expval)
+        self._epsilon = epsilon
+
+    def evaluate_seq(
+        self,
+        parameters: Union[list[float], np.ndarray],
+        **run_options,
+    ) -> ExpectationValueGradientResult:
+        if isinstance(parameters, np.ndarray):
+            if len(parameters.shape) != 1:
+                raise ValueError("parameters should be a vector")
+            else:
+                parameters = parameters.tolist()
+        parameters = cast(list[float], parameters)
+        dim = len(parameters)
+        todo = [parameters]
+
+        # preprocessing
+        for i in range(dim):
+            ei = parameters.copy()
+            ei[i] += self._epsilon
+            todo.append(ei)
+
+        # execution
+        results = []
+        for param in todo:
+            results.append(self._expval.evaluate(param, **run_options))
+
+        # postprocessing
+        grad = np.zeros(dim)
+        f_ref = results[0].value
+        for i, result in enumerate(results[1:]):
+            f_i = result.value
+            grad[i] = (f_i - f_ref) / self._epsilon
+
+        return ExpectationValueGradientResult(values=grad)
+
+    def evaluate(
+        self,
+        parameters: Union[list[float], np.ndarray],
+        **run_options,
+    ) -> ExpectationValueGradientResult:
+        if isinstance(parameters, np.ndarray):
+            if len(parameters.shape) != 1:
+                raise ValueError("parameters should be a vector")
+            else:
+                parameters = parameters.tolist()
+        parameters = cast(list[float], parameters)
+        dim = len(parameters)
+        todo = [parameters]
+
+        # preprocessing
+        for i in range(dim):
+            ei = parameters.copy()
+            ei[i] += self._epsilon
+            todo.append(ei)
+
+        # execution
+        results = self._expval.evaluate(todo, **run_options)
+
+        # postprocessing
+        grad = np.zeros(dim)
+        f_ref = results.items[0].value
+        for i, result in enumerate(results.items[1:]):
+            f_i = result.value
+            grad[i] = (f_i - f_ref) / self._epsilon
+
+        return ExpectationValueGradientResult(values=grad)
+
+
+class ParameterShiftGradient(BaseExpectationValueGradient):
+    """
+    Gradient of expectation values by parameter shift
+    """
+
+    def __init__(self, expval: ExpectationValue):
+        super(ParameterShiftGradient, self).__init__(expval)
+
+    def evaluate(
+        self,
+        parameters: Union[list[float], np.ndarray],
+        **run_options,
+    ) -> ExpectationValueGradientResult:
+        if isinstance(parameters, np.ndarray):
+            if len(parameters.shape) != 1:
+                raise ValueError("parameters should be a vector")
+            else:
+                parameters = parameters.tolist()
+        parameters = cast(list[float], parameters)
+        dim = len(parameters)
+        todo = []
+        epsilon = np.pi / 2
+
+        # preprocessing
+        for i in range(dim):
+            ei = parameters.copy()
+            ei[i] += epsilon
+            todo.append(ei)
+
+            ei = parameters.copy()
+            ei[i] -= epsilon
+            todo.append(ei)
+
+        # execution
+        results = self._expval.evaluate(todo, **run_options)
+
+        # postprocessing
+        div = 2 * np.sin(epsilon)
+        grad = np.zeros(dim)
+        for i in range(dim):
+            f_plus = results.items[2 * i].value
+            f_minus = results.items[2 * i + 1].value
+            grad[i] = (f_plus - f_minus) / div
+
+        return ExpectationValueGradientResult(values=grad)

--- a/qiskit/evaluators/expectation_value/pauli_expectation_value.py
+++ b/qiskit/evaluators/expectation_value/pauli_expectation_value.py
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 
 class PauliExpectationValue(ExpectationValue):
     """
-    Evaluates expectaion value using pauli rotation gates.
+    Evaluates expectation value using pauli rotation gates.
     """
 
     def __init__(

--- a/qiskit/evaluators/expectation_value/pauli_expectation_value.py
+++ b/qiskit/evaluators/expectation_value/pauli_expectation_value.py
@@ -206,7 +206,7 @@ def _expval_with_variance(
                 "(%f). Setting standard deviation of result to 0.",
                 variance,
             )
-        variance = 0.0
+        variance = np.float64(0.0)
     return expval.item(), variance.item()
 
 

--- a/qiskit/evaluators/framework/base_evaluator.py
+++ b/qiskit/evaluators/framework/base_evaluator.py
@@ -20,8 +20,6 @@ from typing import Any, Optional, Union, cast
 
 import numpy as np
 
-import numpy as np
-
 from qiskit import QuantumCircuit, transpile
 from qiskit.evaluators.backends import (
     BackendWrapper,
@@ -154,8 +152,6 @@ class BaseEvaluator:
         run_opts_dict = run_opts.__dict__
 
         # TODO: support Aer parameter bind after https://github.com/Qiskit/qiskit-aer/pull/1317
-        if isinstance(parameters, np.ndarray):
-            parameters = parameters.tolist()
         if parameters is None:
             circuits = self.transpiled_circuits
         else:

--- a/qiskit/evaluators/framework/base_evaluator.py
+++ b/qiskit/evaluators/framework/base_evaluator.py
@@ -20,6 +20,8 @@ from typing import Any, Optional, Union, cast
 
 import numpy as np
 
+import numpy as np
+
 from qiskit import QuantumCircuit, transpile
 from qiskit.evaluators.backends import (
     BackendWrapper,
@@ -152,6 +154,8 @@ class BaseEvaluator:
         run_opts_dict = run_opts.__dict__
 
         # TODO: support Aer parameter bind after https://github.com/Qiskit/qiskit-aer/pull/1317
+        if isinstance(parameters, np.ndarray):
+            parameters = parameters.tolist()
         if parameters is None:
             circuits = self.transpiled_circuits
         else:

--- a/qiskit/evaluators/results/__init__.py
+++ b/qiskit/evaluators/results/__init__.py
@@ -13,5 +13,6 @@
 """Result classes for evaluators."""
 
 from .composite_result import CompositeResult
+from .expectation_value_gradient_result import ExpectationValueGradientResult
 from .expectation_value_array_result import ExpectationValueArrayResult
 from .expectation_value_result import ExpectationValueResult

--- a/qiskit/evaluators/results/__init__.py
+++ b/qiskit/evaluators/results/__init__.py
@@ -13,6 +13,6 @@
 """Result classes for evaluators."""
 
 from .composite_result import CompositeResult
-from .expectation_value_gradient_result import ExpectationValueGradientResult
 from .expectation_value_array_result import ExpectationValueArrayResult
+from .expectation_value_gradient_result import ExpectationValueGradientResult
 from .expectation_value_result import ExpectationValueResult

--- a/qiskit/evaluators/results/expectation_value_gradient_result.py
+++ b/qiskit/evaluators/results/expectation_value_gradient_result.py
@@ -10,16 +10,21 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 """
-Composite result class
+Expectation value gradient result class
 """
 
+from __future__ import annotations
+
+import numpy as np
 
 from .base_result import BaseResult
 
 
-class CompositeResult(BaseResult):
+class ExpectationValueGradientResult(BaseResult):
     """
-    Composite Result
+    Result of ExpectationValueGradient
+    #TODO doc
     """
 
-    items: list[BaseResult]
+    values: np.ndarray  # values or array
+    # metadata: Metadata


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

とりあえずの勾配の実装
- gradientはexpvalをconstructorで受け取るので、`BaseEvaluator` を継承するとconstructorの違いが出たので、あえて継承しなかった
- `ExactExpectationValue`がまだ複数パラメーターに対応していなかったので、`evaluate_seq`というparameterを逐次的に評価するものも暫定的に作った
- gradientもexpvalとは違う形でpreprocessingとpostprocessingに分離できそうだが、とりあえずベタ書き。

```python
import logging
from qiskit.providers.aer import AerSimulator

from qiskit.circuit.library import RealAmplitudes
from qiskit.evaluators import PauliExpectationValue, ExactExpectationValue
from qiskit.evaluators.expectation_value.expectation_value_gradient import FiniteDiffGradient, ParameterShiftGradient
from qiskit.evaluators.backends import ReadoutErrorMitigation
from qiskit.opflow import PauliSumOp
from qiskit.test.mock import FakeMontreal

#logging.basicConfig(level=logging.INFO)

observable = PauliSumOp.from_list([("XX", 1), ("YY", 2), ("ZZ", 3)])
print("observable\n", observable)

ansatz = RealAmplitudes(num_qubits=2, reps=2)
print("ansatz\n", ansatz)

if False:
    prov = IBMQ.load_account()
    backend = prov.get_backend('ibmq_qasm_simulator')
elif False:
    prov = IBMQ.load_account()
    backend = prov.get_backend('ibmq_manila')
    backend = AerSimulator.from_backend(backend)
elif True:
    backend = AerSimulator.from_backend(FakeMontreal())
else:
    backend = AerSimulator()

mit = ReadoutErrorMitigation(backend, mitigation="tensored", refresh=1, shots=2000,
                             mit_pattern=[[0], [1]])

expval = ExactExpectationValue(ansatz, observable, backend=AerSimulator())
findiff = FiniteDiffGradient(expval, 1e-8)
print()
print(f"fin diff of exact {findiff.evaluate_seq([0, 1, 1, 2, 3, 5]).values}")

expval = PauliExpectationValue(ansatz, observable, backend=backend)
findiff = FiniteDiffGradient(expval, 1e-1)
print(f"fin diff w/o mit {findiff.evaluate([0, 1, 1, 2, 3, 5], shots=1000).values}")

expval = PauliExpectationValue(ansatz, observable, backend=backend)
paramshift = ParameterShiftGradient(expval)
print(f"param shift w/o mit {paramshift.evaluate([0, 1, 1, 2, 3, 5], shots=1000).values}")

expval = PauliExpectationValue(ansatz, observable, backend=mit)
findiff = FiniteDiffGradient(expval, 1e-1)
print(f"fin diff w/ mit {findiff.evaluate([0, 1, 1, 2, 3, 5], shots=1000).values}")

expval = PauliExpectationValue(ansatz, observable, backend=mit)
paramshift = ParameterShiftGradient(expval)
print(f"param shift w/ mit {paramshift.evaluate([0, 1, 1, 2, 3, 5], shots=1000).values}")
```

```
observable
 1.0 * XX
+ 2.0 * YY
+ 3.0 * ZZ
ansatz
      ┌──────────┐     ┌──────────┐     ┌──────────┐
q_0: ┤ Ry(θ[0]) ├──■──┤ Ry(θ[2]) ├──■──┤ Ry(θ[4]) ├
     ├──────────┤┌─┴─┐├──────────┤┌─┴─┐├──────────┤
q_1: ┤ Ry(θ[1]) ├┤ X ├┤ Ry(θ[3]) ├┤ X ├┤ Ry(θ[5]) ├
     └──────────┘└───┘└──────────┘└───┘└──────────┘

fin diff of exact [0.1351032  1.87744369 1.03215414 1.87744362 1.48950672 2.15662819]
/home/ima/github/qiskit/terra/qiskit/evaluators/expectation_value/expectation_value_gradient.py:111: ComplexWarning: Casting complex values to real discards the imaginary part
  grad[i] = (f_i - f_ref) / self._epsilon
fin diff w/o mit [1.86 2.16 2.96 3.5  3.32 3.96]
/home/ima/github/qiskit/terra/qiskit/evaluators/expectation_value/expectation_value_gradient.py:158: ComplexWarning: Casting complex values to real discards the imaginary part
  grad[i] = (f_plus - f_minus) / div
param shift w/o mit [0.156 1.631 0.987 1.558 1.212 1.812]
fin diff w/ mit [1.84760722 0.58087798 3.99919714 2.40274211 2.55413478 4.45897306]
param shift w/ mit [0.10787925 1.80142304 1.23407844 1.85361092 1.41248085 2.10881178]
```

### Details and comments


